### PR TITLE
v2.0.07

### DIFF
--- a/Info Grid/CHANGEDB.php
+++ b/Info Grid/CHANGEDB.php
@@ -86,3 +86,8 @@ UPDATE `gibbonAction` SET menuShow = 'N' WHERE name='View Info Grid' AND gibbonM
 ++$count;
 $sql[$count][0] = '2.0.06';
 $sql[$count][1] = '';
+
+//v2.0.07
+++$count;
+$sql[$count][0] = '2.0.07';
+$sql[$count][1] = '';

--- a/Info Grid/CHANGELOG.txt
+++ b/Info Grid/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v2.0.07
+-------
+Fixed PHP file include error on the dashboard
+
 v2.0.06
 -------
 Fixed PHP execution vulnerability 

--- a/Info Grid/hook_dashboard_infoGridView.php
+++ b/Info Grid/hook_dashboard_infoGridView.php
@@ -21,17 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 $returnInt = null;
 
-//Only include module include if it is not already included (which it may be been on the index page)
-$included = false;
-$includes = get_included_files();
-foreach ($includes as $include) {
-    if ($include == $_SESSION[$guid]['absolutePath'].'/modules/Info Grid/moduleFunctions.php') {
-        $included = true;
-    }
-}
-if ($included == false) {
-    include './modules/Info Grid/moduleFunctions.php';
-}
+include_once './modules/Info Grid/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Info Grid/infoGrid_view.php') == false) {
     //Acess denied

--- a/Info Grid/manifest.php
+++ b/Info Grid/manifest.php
@@ -25,7 +25,7 @@ $description = 'Offers school-defined image-grids of links to useful resources, 
 $entryURL = 'infoGrid_manage.php';
 $type = 'Additional';
 $category = 'Other';
-$version = '2.0.06';
+$version = '2.0.07';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/Info Grid/version.php
+++ b/Info Grid/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '2.0.06';
+$moduleVersion = '2.0.07';


### PR DESCRIPTION
Fixes a PHP error where the info grid tab would break for families with multiple children:
`Fatal error: Cannot redeclare getInfoGrid()` because the moduleFunctions file was being included more than once.